### PR TITLE
Fix generic extend would incorrectly narrow string literal union type into string constant.

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -2,11 +2,11 @@ import React from "react";
 import {Action, State} from "./reducer";
 import {useDispatch, useSelector} from "react-redux";
 
+type DeferLiteralArrayCheck<T> = T extends Array<string | number | boolean | null | undefined> ? T : never;
+
 export function useLoadingStatus(identifier: string = "global"): boolean {
     return useSelector((state: State) => state.loading[identifier] > 0);
 }
-
-type DeferLiteralArrayCheck<T> = T extends Array<string | number | boolean | null | undefined> ? T : never;
 
 /**
  * For actions like:

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -6,6 +6,8 @@ export function useLoadingStatus(identifier: string = "global"): boolean {
     return useSelector((state: State) => state.loading[identifier] > 0);
 }
 
+type DeferLiteralArrayCheck<T> = T extends Array<string | number | boolean | null | undefined> ? T : never;
+
 /**
  * For actions like:
  * *foo(a: number, b: string, c: boolean): SagaIterator {..}
@@ -22,7 +24,7 @@ export function useLoadingStatus(identifier: string = "global"): boolean {
  * useModuleAction(foo, 100, "", true) will return:
  * () => void;
  */
-export function useModuleAction<T extends Array<string | number | boolean | null | undefined>, U extends any[]>(actionCreator: (...args: [...T, ...U]) => Action<[...T, ...U]>, ...deps: T): (...args: U) => void {
+export function useModuleAction<T extends any[], U extends any[]>(actionCreator: (...args: [...T, ...U]) => Action<[...DeferLiteralArrayCheck<T>, ...U]>, ...deps: T): (...args: U) => void {
     const dispatch = useDispatch();
     return React.useCallback((...args: U) => dispatch(actionCreator(...deps, ...args)), [dispatch, actionCreator, ...deps]);
 }

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -1,0 +1,61 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+import {SagaIterator, useModuleAction as useModuleActionImpl} from "../src";
+import {Action} from "../src/reducer";
+
+type ActionCreator<P extends any[]> = (...args: P) => Action<P>;
+
+// Only test type
+const useModuleAction: typeof useModuleActionImpl = (() => () => {}) as any;
+
+describe("useModuleAction(type test)", () => {
+    test("Should accept ActionCreator with only primitive dependency", () => {
+        const allPrimitiveActionCreator: ActionCreator<[number, string, number]> = (a, b, c) => ({type: "test", payload: [a, b, c]});
+
+        const curry1 = useModuleAction(allPrimitiveActionCreator, 1);
+        const expectCurry1ToPass = curry1("", 3);
+
+        const curry2 = useModuleAction(allPrimitiveActionCreator, 1, "2");
+        const expectCurry2ToPass = curry2(3);
+
+        const allCurry = useModuleAction(allPrimitiveActionCreator, 1, "", 3);
+        const expectAllCurryToPass = allCurry();
+
+        test("Should reject ActionCreators with object as deps", () => {
+            const updateAction: ActionCreator<[string, {value: number}]> = (id: string, data: {value: number}) => ({type: "test", payload: [id, data]});
+            const noDeps = useModuleAction(updateAction);
+            const expectToPass = noDeps("id", {value: 2});
+
+            const updateDataWithId = useModuleAction(updateAction, "sample id");
+            const expectUpdateWithIdToPass = updateDataWithId({value: 3});
+
+            // @ts-expect-error
+            const updateDataWithObject = useModuleAction(updateAction, "id", {value: 2});
+        });
+
+        test("type union test", () => {
+            const createTabChangeAction: ActionCreator<["a" | "b" | "c"]> = (tab) => ({type: "String Union test", payload: [tab]});
+            const changeToA = useModuleAction(createTabChangeAction, "a");
+            const changeToB = useModuleAction(createTabChangeAction, "b");
+            const changeToC = useModuleAction(createTabChangeAction, "c");
+
+            // @ts-expect-error
+            const expectToFail = useModuleAction(createTabChangeAction, "not valid");
+            // @ts-expect-error
+            const expectToFail = useModuleAction(createTabChangeAction, null);
+            // @ts-expect-error
+            const shouldNotHaveParam = changeToA(1);
+
+            const shouldBeSameFunction = useModuleAction(createTabChangeAction);
+
+            const expectToPassA = shouldBeSameFunction("a");
+            const expectToPassB = shouldBeSameFunction("b");
+            const expectToPassC = shouldBeSameFunction("c");
+
+            // @ts-expect-error
+            const expectToFailNumber = shouldBeSameFunction(1);
+            // @ts-expect-error
+            const expectToFailString = shouldBeSameFunction("not valid");
+        });
+    });
+});

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -14,9 +14,13 @@ describe("useModuleAction(type test)", () => {
 
         const curry1 = useModuleAction(allPrimitiveActionCreator, 1);
         const expectCurry1ToPass = curry1("", 3);
+        // @ts-expect-error
+        const expectWrongParamToFail = curry1(3, "s");
 
         const curry2 = useModuleAction(allPrimitiveActionCreator, 1, "2");
         const expectCurry2ToPass = curry2(3);
+        // @ts-expect-error
+        const expectWrongParamToFail = curry2("s");
 
         const allCurry = useModuleAction(allPrimitiveActionCreator, 1, "", 3);
         const expectAllCurryToPass = allCurry();

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -10,56 +10,72 @@ const useModuleAction: typeof useModuleActionImpl = (() => () => {}) as any;
 
 describe("useModuleAction(type test)", () => {
     test("Should accept ActionCreator with only primitive dependency", () => {
-        const allPrimitiveActionCreator: ActionCreator<[number, string, number]> = (a, b, c) => ({type: "test", payload: [a, b, c]});
+        const allPrimitiveActionCreator: ActionCreator<[number, string, boolean]> = (a, b, c) => ({type: "test", payload: [a, b, c]});
 
         const curry1 = useModuleAction(allPrimitiveActionCreator, 1);
-        const expectCurry1ToPass = curry1("", 3);
+        const expectCurry1ToPass = curry1("", false);
         // @ts-expect-error
         const expectWrongParamToFail = curry1(3, "s");
 
         const curry2 = useModuleAction(allPrimitiveActionCreator, 1, "2");
-        const expectCurry2ToPass = curry2(3);
+        const expectCurry2ToPass = curry2(true);
         // @ts-expect-error
         const expectWrongParamToFail = curry2("s");
 
         const allCurry = useModuleAction(allPrimitiveActionCreator, 1, "", 3);
         const expectAllCurryToPass = allCurry();
+    });
 
-        test("Should reject ActionCreators with object as deps", () => {
-            const updateAction: ActionCreator<[string, {value: number}]> = (id: string, data: {value: number}) => ({type: "test", payload: [id, data]});
-            const noDeps = useModuleAction(updateAction);
-            const expectToPass = noDeps("id", {value: 2});
+    test("Should reject ActionCreators with object as deps", () => {
+        const updateAction: ActionCreator<[string, {value: number}]> = (id: string, data: {value: number}) => ({type: "test", payload: [id, data]});
+        const noDeps = useModuleAction(updateAction);
+        const expectToPass = noDeps("id", {value: 2});
 
-            const updateDataWithId = useModuleAction(updateAction, "sample id");
-            const expectUpdateWithIdToPass = updateDataWithId({value: 3});
+        const updateDataWithId = useModuleAction(updateAction, "sample id");
+        const expectUpdateWithIdToPass = updateDataWithId({value: 3});
 
-            // @ts-expect-error
-            const updateDataWithObject = useModuleAction(updateAction, "id", {value: 2});
-        });
+        // @ts-expect-error
+        const updateDataWithObject = useModuleAction(updateAction, "id", {value: 2});
+    });
 
-        test("type union test", () => {
-            const createTabChangeAction: ActionCreator<["a" | "b" | "c"]> = (tab) => ({type: "String Union test", payload: [tab]});
-            const changeToA = useModuleAction(createTabChangeAction, "a");
-            const changeToB = useModuleAction(createTabChangeAction, "b");
-            const changeToC = useModuleAction(createTabChangeAction, "c");
+    test("type union test", () => {
+        const createTabChangeAction: ActionCreator<["a" | "b" | "c"]> = (tab) => ({type: "String Union test", payload: [tab]});
 
-            // @ts-expect-error
-            const expectToFail = useModuleAction(createTabChangeAction, "not valid");
-            // @ts-expect-error
-            const expectToFail = useModuleAction(createTabChangeAction, null);
-            // @ts-expect-error
-            const shouldNotHaveParam = changeToA(1);
+        const changeToA = useModuleAction(createTabChangeAction, "a");
+        const changeToB = useModuleAction(createTabChangeAction, "b");
+        const changeToC = useModuleAction(createTabChangeAction, "c");
+        const expectPassA = changeToA();
+        const expectPassB = changeToB();
+        const expectPassC = changeToC();
 
-            const shouldBeSameFunction = useModuleAction(createTabChangeAction);
+        // @ts-expect-error
+        const expectToFail = useModuleAction(createTabChangeAction, "not valid");
+        // @ts-expect-error
+        const expectToFail = useModuleAction(createTabChangeAction, null);
+        // @ts-expect-error
+        const shouldNotHaveParam = changeToA(1);
 
-            const expectToPassA = shouldBeSameFunction("a");
-            const expectToPassB = shouldBeSameFunction("b");
-            const expectToPassC = shouldBeSameFunction("c");
+        const shouldBeSameFunction = useModuleAction(createTabChangeAction);
 
-            // @ts-expect-error
-            const expectToFailNumber = shouldBeSameFunction(1);
-            // @ts-expect-error
-            const expectToFailString = shouldBeSameFunction("not valid");
-        });
+        const expectToPassA = shouldBeSameFunction("a");
+        const expectToPassB = shouldBeSameFunction("b");
+        const expectToPassC = shouldBeSameFunction("c");
+
+        // @ts-expect-error
+        const expectToFailNumber = shouldBeSameFunction(1);
+        // @ts-expect-error
+        const expectToFailString = shouldBeSameFunction("not valid");
+    });
+
+    test("String literal union with multiple param", () => {
+        const createTabChangeAction: ActionCreator<["a" | "b" | "c", {data: string}]> = (tab, data) => ({type: "String Union test", payload: [tab, data]});
+        const changeToA = useModuleAction(createTabChangeAction, "a");
+        const changeToB = useModuleAction(createTabChangeAction, "b");
+        const changeToC = useModuleAction(createTabChangeAction, "c");
+
+        const expectChangeToAToPass = changeToA({data: "test"});
+
+        // @ts-expect-error
+        const expectToFail = changeToA("");
     });
 });


### PR DESCRIPTION
The deferral of Literal Array requirement check would make the error message very cryptic, because `DeferLiteralArrayCheck` would convert to `never`
<img width="1509" alt="image" src="https://user-images.githubusercontent.com/5446782/90860141-12fabb00-e3bc-11ea-86c1-d424a7b96a4d.png">

