### PR TITLE
Simplified useModuleAction

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -9,23 +9,6 @@ export function useLoadingStatus(identifier: string = "global"): boolean {
 }
 
 /**
- * For actions like:
- * *foo(a: number, b: string, c: boolean): SagaIterator {..}
- *
- * useModuleAction(foo) will return:
- * (a: number, b: string, c: boolean) => void;
- *
- * useModuleAction(foo, 100) will return:
- * (b: string, c: boolean) => void;
- *
- * useModuleAction(foo, 100, "") will return:
- * (c: boolean) => void;
- *
- * useModuleAction(foo, 100, "", true) will return:
- * () => void;
- */
-
-/**
  * Action parameters must be of primitive types, so that the dependency check can work well.
  * No need add dispatch to dep list, because it is always fixed.
  */
@@ -34,6 +17,13 @@ export function useAction<P extends Array<string | number | boolean | null | und
     return React.useCallback(() => dispatch(actionCreator(...deps)), deps);
 }
 
+/**
+ * For actions like:
+ * *foo(a: number, b: string, c: boolean): SagaIterator {..}
+ *
+ * useModuleAction(foo, 100, "") will return:
+ * (c: boolean) => void;
+ */
 export function useUnaryAction<P extends any[], U>(actionCreator: (...args: [...P, U]) => Action<[...DeferLiteralArrayCheck<P>, U]>, ...deps: P): (arg: U) => void {
     const dispatch = useDispatch();
     return React.useCallback((arg: U) => dispatch(actionCreator(...deps, arg)), deps);

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -24,9 +24,19 @@ export function useLoadingStatus(identifier: string = "global"): boolean {
  * useModuleAction(foo, 100, "", true) will return:
  * () => void;
  */
-export function useModuleAction<T extends any[], U extends any[]>(actionCreator: (...args: [...T, ...U]) => Action<[...DeferLiteralArrayCheck<T>, ...U]>, ...deps: T): (...args: U) => void {
+
+/**
+ * Action parameters must be of primitive types, so that the dependency check can work well.
+ * No need add dispatch to dep list, because it is always fixed.
+ */
+export function useAction<P extends Array<string | number | boolean | null | undefined>>(actionCreator: (...args: P) => Action<P>, ...deps: P): () => void {
     const dispatch = useDispatch();
-    return React.useCallback((...args: U) => dispatch(actionCreator(...deps, ...args)), [dispatch, actionCreator, ...deps]);
+    return React.useCallback(() => dispatch(actionCreator(...deps)), deps);
+}
+
+export function useUnaryAction<P extends any[], U>(actionCreator: (...args: [...P, U]) => Action<[...DeferLiteralArrayCheck<P>, U]>, ...deps: P): (arg: U) => void {
+    const dispatch = useDispatch();
+    return React.useCallback((arg: U) => dispatch(actionCreator(...deps, arg)), deps);
 }
 
 /**
@@ -36,7 +46,7 @@ export function useModuleAction<T extends any[], U extends any[]>(actionCreator:
  * useModuleObjectAction(foo, "key") will return:
  * (objectValue: number) => void;
  */
-export function useModuleObjectAction<T extends object, K extends keyof T>(actionCreator: (arg: T) => Action<[T]>, objectKey: K): (objectValue: T[K]) => void {
+export function useObjectKeyAction<T extends object, K extends keyof T>(actionCreator: (arg: T) => Action<[T]>, objectKey: K): (objectValue: T[K]) => void {
     const dispatch = useDispatch();
     return React.useCallback((objectValue: T[K]) => dispatch(actionCreator({[objectKey]: objectValue} as T)), [dispatch, actionCreator, objectKey]);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,6 @@ export {createActionHandlerDecorator, Loading, Interval, Mutex, RetryOnNetworkCo
 export {Exception, APIException, NetworkConnectionException} from "./Exception";
 export {showLoading, loadingAction, navigationPreventionAction, State} from "./reducer";
 export {register, ErrorListener} from "./module";
-export {useLoadingStatus, useModuleAction, useModuleObjectAction} from "./hooks";
+export {useLoadingStatus, useAction, useObjectKeyAction, useUnaryAction} from "./hooks";
 export {SagaIterator, call, put, spawn, delay, all, race} from "./typed-saga";
 export {logger} from "./app";

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -1,15 +1,10 @@
-import {useAction, useObjectKeyAction, useUnaryAction} from "../src";
-import {Action as ReduxAction} from "redux";
+import {useAction, useObjectKeyAction, useUnaryAction} from "../src/hooks";
+import {Action} from "../src/reducer";
 
 /**
  * Using real useModuleAction in Jest environment will error, because the hooks are not called in a React component context.
  */
-jest.mock("../src/hooks", () => ({useModuleAction: () => () => {}}));
-
-interface Action<P> extends ReduxAction<string> {
-    payload: P;
-    name?: undefined;
-}
+jest.mock("../src/hooks", () => ({useAction: () => () => {}, useUnaryAction: () => () => {}, useObjectKeyAction: () => () => {}}));
 
 type ActionCreator<P extends any[]> = (...args: P) => Action<P>;
 

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -1,80 +1,58 @@
-import {useModuleAction} from "../src/hooks";
-import {Action} from "../src/reducer";
+import {useAction, useObjectKeyAction, useUnaryAction} from "../src";
+import {Action as ReduxAction} from "redux";
 
 /**
  * Using real useModuleAction in Jest environment will error, because the hooks are not called in a React component context.
  */
 jest.mock("../src/hooks", () => ({useModuleAction: () => () => {}}));
 
+interface Action<P> extends ReduxAction<string> {
+    payload: P;
+    name?: undefined;
+}
+
 type ActionCreator<P extends any[]> = (...args: P) => Action<P>;
 
-describe("useModuleAction(type test)", () => {
+describe("useAction(type test)", () => {
     test("Should accept ActionCreator with only primitive dependency", () => {
         const allPrimitiveActionCreator: ActionCreator<[number, string, boolean]> = (a, b, c) => ({type: "test", payload: [a, b, c]});
 
-        const curry1 = useModuleAction(allPrimitiveActionCreator, 1);
-        const expectCurry1ToPass = curry1("", false);
-        // @ts-expect-error
-        const expectWrongParamToFail = curry1(3, "s");
-
-        const curry2 = useModuleAction(allPrimitiveActionCreator, 1, "2");
-        const expectCurry2ToPass = curry2(true);
-        // @ts-expect-error
-        const expectWrongParamToFail = curry2("s");
-
-        const allCurry = useModuleAction(allPrimitiveActionCreator, 1, "", false);
+        const allCurry = useAction(allPrimitiveActionCreator, 1, "", false);
         const expectAllCurryToPass = allCurry();
     });
 
     test("Should reject ActionCreators with object as deps", () => {
         const updateAction: ActionCreator<[string, {value: number}]> = (id: string, data: {value: number}) => ({type: "test", payload: [id, data]});
-        const noDeps = useModuleAction(updateAction);
-        const expectToPass = noDeps("id", {value: 2});
-
-        const updateDataWithId = useModuleAction(updateAction, "sample id");
-        const expectUpdateWithIdToPass = updateDataWithId({value: 3});
-
         // @ts-expect-error
-        const updateDataWithObject = useModuleAction(updateAction, "id", {value: 2});
+        const updateDataWithObject = useAction(updateAction, "id", {value: 2});
     });
 
     test("type union test", () => {
         const createTabChangeAction: ActionCreator<["a" | "b" | "c"]> = (tab) => ({type: "String Union test", payload: [tab]});
 
-        const changeToA = useModuleAction(createTabChangeAction, "a");
-        const changeToB = useModuleAction(createTabChangeAction, "b");
-        const changeToC = useModuleAction(createTabChangeAction, "c");
+        const changeToA = useAction(createTabChangeAction, "a");
+        const changeToB = useAction(createTabChangeAction, "b");
+        const changeToC = useAction(createTabChangeAction, "c");
         const expectPassA = changeToA();
         const expectPassB = changeToB();
         const expectPassC = changeToC();
 
         // @ts-expect-error
-        const expectToFail = useModuleAction(createTabChangeAction, "not valid");
+        const expectToFail = useAction(createTabChangeAction, "not valid");
         // @ts-expect-error
-        const expectToFail = useModuleAction(createTabChangeAction, null);
+        const expectToFail = useAction(createTabChangeAction, null);
         // @ts-expect-error
         const shouldNotHaveParam = changeToA(1);
-
-        const shouldBeSameFunction = useModuleAction(createTabChangeAction);
-
-        const expectToPassA = shouldBeSameFunction("a");
-        const expectToPassB = shouldBeSameFunction("b");
-        const expectToPassC = shouldBeSameFunction("c");
-
-        // @ts-expect-error
-        const expectToFailNumber = shouldBeSameFunction(1);
-        // @ts-expect-error
-        const expectToFailString = shouldBeSameFunction("not valid");
     });
 
     test("String literal union with multiple param", () => {
         const createTabChangeAction: ActionCreator<["a" | "b" | "c" | null | undefined | 100, {data: string}]> = (tab, data) => ({type: "String Union test", payload: [tab, data]});
-        const changeToA = useModuleAction(createTabChangeAction, "a");
-        const changeToB = useModuleAction(createTabChangeAction, "b");
-        const changeToC = useModuleAction(createTabChangeAction, "c");
-        const changeToNull = useModuleAction(createTabChangeAction, null);
-        const changeToUndefined = useModuleAction(createTabChangeAction, undefined);
-        const changeTo100 = useModuleAction(createTabChangeAction, 100);
+        const changeToA = useUnaryAction(createTabChangeAction, "a");
+        const changeToB = useUnaryAction(createTabChangeAction, "b");
+        const changeToC = useUnaryAction(createTabChangeAction, "c");
+        const changeToNull = useUnaryAction(createTabChangeAction, null);
+        const changeToUndefined = useUnaryAction(createTabChangeAction, undefined);
+        const changeTo100 = useUnaryAction(createTabChangeAction, 100);
 
         const expectChangeToAToPass = changeToA({data: "test"});
 
@@ -82,5 +60,76 @@ describe("useModuleAction(type test)", () => {
         const expectToFail1 = changeToA();
         // @ts-expect-error
         const expectToFail2 = changeToA("");
+    });
+});
+
+describe("useUnaryAction(type test)", () => {
+    test("Should curry id", () => {
+        const updateAction: ActionCreator<[string, {value: number}]> = (id: string, data: {value: number}) => ({type: "test", payload: [id, data]});
+        const updateObjectWithId = useUnaryAction(updateAction, "id");
+        updateObjectWithId({value: 1});
+
+        // @ts-expect-error
+        updateObjectWithId({value: "s"});
+    });
+
+    test("String literal union with multiple param", () => {
+        const createTabChangeAction: ActionCreator<["a" | "b" | "c" | null | undefined | 100, {data: string}]> = (tab, data) => ({type: "String Union test", payload: [tab, data]});
+        const changeToA = useUnaryAction(createTabChangeAction, "a");
+        const changeToB = useUnaryAction(createTabChangeAction, "b");
+        const changeToC = useUnaryAction(createTabChangeAction, "c");
+        const changeToNull = useUnaryAction(createTabChangeAction, null);
+        const changeToUndefined = useUnaryAction(createTabChangeAction, undefined);
+        const changeTo100 = useUnaryAction(createTabChangeAction, 100);
+
+        const expectChangeToAToPass = changeToA({data: "test"});
+
+        // @ts-expect-error
+        const expectToFail1 = changeToA();
+        // @ts-expect-error
+        const expectToFail2 = changeToA("");
+    });
+
+    test("Curry with type union args", () => {
+        const createTabChangeAction: ActionCreator<[id: string, tabId: "a" | "b" | "c" | null | undefined | 100]> = (id, tabId) => ({type: "String Union test", payload: [id, tabId]});
+        const changeTab = useUnaryAction(createTabChangeAction, "test");
+        changeTab("a");
+
+        // @ts-expect-error
+        changeTab("d");
+
+        // @ts-expect-error
+        changeTab({});
+    });
+});
+
+describe("useModuleObjectKeyAction(type test)", () => {
+    test("Should accept key of object", () => {
+        const updateObjectAction: ActionCreator<[{a: string; b: number; c: boolean; d: null | "a" | "b"}]> = (object) => ({type: "update object", payload: [object]});
+        const updateA = useObjectKeyAction(updateObjectAction, "a");
+        const updateB = useObjectKeyAction(updateObjectAction, "b");
+        const updateC = useObjectKeyAction(updateObjectAction, "c");
+        const updateD = useObjectKeyAction(updateObjectAction, "d");
+
+        // @ts-expect-error
+        const updateNotKey = useObjectKeyAction(updateObjectAction, "NOT KEY");
+
+        updateA("string");
+        updateB(1);
+        updateC(false);
+        updateD(null);
+        updateD("a");
+        updateD("b");
+
+        // @ts-expect-error
+        updateA(1);
+        // @ts-expect-error
+        updateB("s");
+        // @ts-expect-error
+        updateC(3);
+        // @ts-expect-error
+        updateD("e");
+        // @ts-expect-error
+        updateD(undefined);
     });
 });


### PR DESCRIPTION
This PR simplifies the usage of useModuleAction, the primary purpose to is prevent unwanted parameters passed into curried function.` (...T) => void` when T is 0-length

Changes( all breaking changes)

`useAction`: Creates a 0-arg call back, known previously as `useModuleAction`
`useUnaryAction`: Creates a 1-arg call back, primarily used for `onChange` function
`useuObjectKeyAction`: No change, Known previously as `useModuleObjectAction`