### PR TITLE
Fix useUnaryAction would accept an action with no args

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -4,8 +4,6 @@ import {useDispatch, useSelector} from "react-redux";
 
 type DeferLiteralArrayCheck<T> = T extends Array<string | number | boolean | null | undefined> ? T : never;
 
-type NonEmptyAction<P extends any[], U> = Action<[...P, U] extends [] | [any] ? never : any[]>;
-
 export function useLoadingStatus(identifier: string = "global"): boolean {
     return useSelector((state: State) => state.loading[identifier] > 0);
 }
@@ -26,7 +24,7 @@ export function useAction<P extends Array<string | number | boolean | null | und
  * useUnaryAction(foo, 100, "") will return:
  * (c: boolean) => void;
  */
-export function useUnaryAction<P extends any[], U>(actionCreator: (...args: [...P, U]) => NonEmptyAction<DeferLiteralArrayCheck<P>, U>, ...deps: P): (arg: U) => void {
+export function useUnaryAction<P extends any[], U>(actionCreator: (...args: [...P, U]) => Action<[...DeferLiteralArrayCheck<P>, U]>, ...deps: P): (arg: U) => void {
     const dispatch = useDispatch();
     return React.useCallback((arg: U) => dispatch(actionCreator(...deps, arg)), deps);
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -2,7 +2,9 @@ import React from "react";
 import {Action, State} from "./reducer";
 import {useDispatch, useSelector} from "react-redux";
 
-type DeferLiteralArrayCheck<T> = T extends Array<string | number | boolean | null | undefined> ? any[] : never;
+type DeferLiteralArrayCheck<T> = T extends Array<string | number | boolean | null | undefined> ? T : never;
+
+type NonEmpty<P extends any[], U> = Action<[...P, U] extends [] | [any] ? never : any[]>;
 
 export function useLoadingStatus(identifier: string = "global"): boolean {
     return useSelector((state: State) => state.loading[identifier] > 0);
@@ -24,7 +26,7 @@ export function useAction<P extends Array<string | number | boolean | null | und
  * useUnaryAction(foo, 100, "") will return:
  * (c: boolean) => void;
  */
-export function useUnaryAction<P extends any[], U>(actionCreator: (...args: [...P, U]) => Action<[...DeferLiteralArrayCheck<P>, U]>, ...deps: P): (arg: U) => void {
+export function useUnaryAction<P extends any[], U>(actionCreator: (...args: [...P, U]) => NonEmpty<DeferLiteralArrayCheck<P>, U>, ...deps: P): (arg: U) => void {
     const dispatch = useDispatch();
     return React.useCallback((arg: U) => dispatch(actionCreator(...deps, arg)), deps);
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -4,7 +4,7 @@ import {useDispatch, useSelector} from "react-redux";
 
 type DeferLiteralArrayCheck<T> = T extends Array<string | number | boolean | null | undefined> ? T : never;
 
-type NonEmpty<P extends any[], U> = Action<[...P, U] extends [] | [any] ? never : any[]>;
+type NonEmptyAction<P extends any[], U> = Action<[...P, U] extends [] | [any] ? never : any[]>;
 
 export function useLoadingStatus(identifier: string = "global"): boolean {
     return useSelector((state: State) => state.loading[identifier] > 0);
@@ -26,7 +26,7 @@ export function useAction<P extends Array<string | number | boolean | null | und
  * useUnaryAction(foo, 100, "") will return:
  * (c: boolean) => void;
  */
-export function useUnaryAction<P extends any[], U>(actionCreator: (...args: [...P, U]) => NonEmpty<DeferLiteralArrayCheck<P>, U>, ...deps: P): (arg: U) => void {
+export function useUnaryAction<P extends any[], U>(actionCreator: (...args: [...P, U]) => NonEmptyAction<DeferLiteralArrayCheck<P>, U>, ...deps: P): (arg: U) => void {
     const dispatch = useDispatch();
     return React.useCallback((arg: U) => dispatch(actionCreator(...deps, arg)), deps);
 }

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -155,6 +155,30 @@ describe("useBinaryAction(type test)", () => {
         update("d", {data: "100"});
     });
 
+    test("Curry union null dep type params", () => {
+        const action: ActionCreator<["a" | "b" | "c" | null | undefined | 100, {data: string}, moreData: string]> = (tab, data) => ({type: "String Union test", payload: [tab, data, "more-data"]});
+
+        const update = useBinaryAction(action, null);
+        update({data: "100"}, "moreData");
+
+        const updateA = useBinaryAction(action, "a");
+        updateA({data: "100"}, "moreData");
+
+        const updateB = useBinaryAction(action, "b");
+        updateB({data: "100"}, "moreData");
+
+        const updateObject1 = useBinaryAction(action, 100);
+        const updateObject2 = useBinaryAction(action, "a");
+
+        updateObject1({data: "good data"}, "more-data");
+        // @ts-expect-error
+        updateObject1("d");
+        // @ts-expect-error
+        updateObject2("a", {data: 5});
+        // @ts-expect-error
+        updateObject2("d", {data: "100"});
+    });
+
     test("Misuse no-arg action", () => {
         const noArgAction: ActionCreator<[]> = () => ({type: "test", payload: []});
         // @ts-expect-error

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -59,6 +59,12 @@ describe("useAction(type test)", () => {
 });
 
 describe("useUnaryAction(type test)", () => {
+    test("Misuse no-arg action", () => {
+        const noArgAction: ActionCreator<[]> = () => ({type: "test", payload: []});
+        // @ts-expect-error
+        const curried = useUnaryAction(noArgAction);
+    });
+
     test("Should curry id", () => {
         const updateAction: ActionCreator<[string, {value: number}]> = (id: string, data: {value: number}) => ({type: "test", payload: [id, data]});
         const updateObjectWithId = useUnaryAction(updateAction, "id");
@@ -66,6 +72,13 @@ describe("useUnaryAction(type test)", () => {
 
         // @ts-expect-error
         updateObjectWithId({value: "s"});
+    });
+
+    test("Cannot use object as dependency", () => {
+        const updateAction: ActionCreator<[string, {value: number}, number]> = (id: string, data: {value: number}, number: number) => ({type: "test", payload: [id, data, number]});
+
+        //  @ts-expect-error
+        const cannotUseObjectAsDeps = useUnaryAction(updateAction, "", {value: 1});
     });
 
     test("String literal union with multiple param", () => {

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -154,6 +154,19 @@ describe("useBinaryAction(type test)", () => {
         // @ts-expect-error
         update("d", {data: "100"});
     });
+
+    test("Misuse no-arg action", () => {
+        const noArgAction: ActionCreator<[]> = () => ({type: "test", payload: []});
+        // @ts-expect-error
+        useBinaryAction(noArgAction);
+    });
+    test("Misuse 1-arg action", () => {
+        const oneArgAction: ActionCreator<[number]> = (id) => ({type: "test", payload: [id]});
+        // @ts-expect-error
+        useBinaryAction(oneArgAction, 1);
+        // @ts-expect-error
+        useBinaryAction(oneArgAction);
+    });
 });
 
 describe("useModuleObjectKeyAction(type test)", () => {

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -65,6 +65,11 @@ describe("useUnaryAction(type test)", () => {
         const curried = useUnaryAction(noArgAction);
     });
 
+    test("single-arg action", () => {
+        const noArgAction: ActionCreator<[string]> = () => ({type: "test", payload: [""]});
+        const curried = useUnaryAction(noArgAction);
+    });
+
     test("Should curry id", () => {
         const updateAction: ActionCreator<[string, {value: number}]> = (id: string, data: {value: number}) => ({type: "test", payload: [id, data]});
         const updateObjectWithId = useUnaryAction(updateAction, "id");

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -179,6 +179,18 @@ describe("useBinaryAction(type test)", () => {
         updateObject2("d", {data: "100"});
     });
 
+    test("Curry union type union arg test", () => {
+        const action: ActionCreator<[string, "a" | "b" | "c" | null | undefined | 100, {data: string}]> = (moreData, tab, data) => ({type: "String Union test", payload: [moreData, tab, data]});
+
+        const update = useBinaryAction(action, "null");
+        update("a", {data: "payload"});
+        update("b", {data: "payload"});
+        update("c", {data: "payload"});
+        update(null, {data: "payload"});
+        update(undefined, {data: "payload"});
+        update(100, {data: "payload"});
+    });
+
     test("Misuse no-arg action", () => {
         const noArgAction: ActionCreator<[]> = () => ({type: "test", payload: []});
         // @ts-expect-error


### PR DESCRIPTION
Modified `DeferLiteralArrayCheck` to return original Type

`DeferLiteralArrayCheck` returning any[] seems to be the culprit that made `useUnaryAction` too relaxed. 

`DeferLiteralArrayCheck` returning any[] is because of original `useModuleAction` null issue ref: [026837b](https://github.com/neowu/core-fe-project/commit/026837b5a7a90c31cdea36952b05a1cc829c1953)

`useUnaryAction`/`useBinaryAction` does not share this issue so we can change `DeferLiteralArrayCheck` to return the actual checked type