### PR TITLE
Update SagaIterator type to pass in TS4.1

### DIFF
--- a/src/typed-saga.ts
+++ b/src/typed-saga.ts
@@ -4,7 +4,7 @@ type SagaGenerator<RT> = Generator<Effect<any>, RT, any>;
 
 type UnwrapReturnType<R> = R extends SagaGenerator<infer RT> ? RT : R extends Promise<infer PromiseValue> ? PromiseValue : R;
 
-export type SagaIterator = IterableIterator<StrictEffect> | Iterator<StrictEffect, any, any>;
+export type SagaIterator = IterableIterator<StrictEffect>;
 
 export function* call<Args extends any[], R>(fn: (...args: Args) => R, ...args: Args): SagaGenerator<UnwrapReturnType<R>> {
     return yield rawCall(fn, ...args);


### PR DESCRIPTION
This PR addresses type checking failing with the following usage:
```ts
class FeatureModule extends Module<RootState, "feature"> {
  @Lifecycle()
  *onEnter(): SagaIterator {
    yield* this.fetchData();
    //     ^^^^^^^^^^^^^^^^
    //     Type 'SagaIterator' is not an array type or does not have a
    //     '[Symbol.iterator()' method that returns an iterator.
  }
  *fetchData(): SagaIterator { /*...*/ }
}
```

TS4.1 probably updated how generators are type checked, and the type definition of `SagaIterator`:
```ts
export type SagaIterator = IterableIterator<StrictEffect> | Iterator<StrictEffect, any, any>;
```
introduces a type branch to a type that does not include the method named `[Symbol.iterator]`.

By removing `Iterator` in the type definition of `SagaIterator`, type check passes in TS4.1.

Since `IterableIterator` extends `Iterator`, it should be safe to make this change.