### PR TITLE
Refactor: Updated onTick logic when in idle

### DIFF
--- a/src/decorator/Interval.ts
+++ b/src/decorator/Interval.ts
@@ -5,12 +5,9 @@ type OnTickHandlerDecorator = (target: object, propertyKey: "onTick", descriptor
 /**
  * For *onTick() action only, to specify to tick interval in second.
  */
-export function Interval(defaultInterval: number, idleInterval?: number): OnTickHandlerDecorator {
+export function Interval(second: number): OnTickHandlerDecorator {
     return (target, propertyKey, descriptor) => {
-        descriptor.value!.tickInterval = defaultInterval;
-        if (idleInterval) {
-            descriptor.value!.idleTickInterval = idleInterval;
-        }
+        descriptor.value!.tickInterval = second;
         return descriptor;
     };
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -9,7 +9,6 @@ import {stringifyWithMask} from "./util/json-util";
 
 export interface TickIntervalDecoratorFlag {
     tickInterval?: number;
-    idleTickInterval?: number;
 }
 
 export type ActionHandler = (...args: any[]) => SagaGenerator;

--- a/src/platform/bootstrap.tsx
+++ b/src/platform/bootstrap.tsx
@@ -49,7 +49,7 @@ interface BootstrapOption {
     browserConfig?: BrowserConfig;
     loggerConfig?: LoggerConfig;
     versionConfig?: VersionConfig;
-    idleTimeoutInSecond?: number; // Default: 5 min
+    idleTimeoutInSecond?: number; // Default: 5 min. Never Idle if timeout value 0 is given
 }
 
 export const LOGGER_ACTION = "@@framework/logger";

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -107,7 +107,7 @@ interface IdleStateActionPayload {
     state: "active" | "idle";
 }
 
-const IDLE_STATE_ACTION = "@@framework/idle-state";
+export const IDLE_STATE_ACTION = "@@framework/idle-state";
 
 export function idleStateActions(state: "active" | "idle"): Action<IdleStateActionPayload> {
     return {

--- a/src/util/IdleDetector.tsx
+++ b/src/util/IdleDetector.tsx
@@ -42,24 +42,26 @@ export function IdleDetector(props: Props) {
     const dispatch = useDispatch();
 
     React.useEffect(() => {
-        const idleTimer = createTimer(timeout, (newIdleState) => {
-            if (newIdleState !== stateRef.current) {
-                dispatch(idleStateActions(newIdleState));
-            }
-        });
-        idleTimer.start();
-        window.addEventListener("click", idleTimer.reset);
-        window.addEventListener("touchmove", idleTimer.reset);
-        window.addEventListener("keydown", idleTimer.reset);
-        window.addEventListener("mousemove", idleTimer.reset);
+        if (timeout > 0) {
+            const idleTimer = createTimer(timeout, (newIdleState) => {
+                if (newIdleState !== stateRef.current) {
+                    dispatch(idleStateActions(newIdleState));
+                }
+            });
+            idleTimer.start();
+            window.addEventListener("click", idleTimer.reset);
+            window.addEventListener("touchmove", idleTimer.reset);
+            window.addEventListener("keydown", idleTimer.reset);
+            window.addEventListener("mousemove", idleTimer.reset);
 
-        return () => {
-            window.removeEventListener("click", idleTimer.reset);
-            window.removeEventListener("touchmove", idleTimer.reset);
-            window.removeEventListener("keydown", idleTimer.reset);
-            window.removeEventListener("mousemove", idleTimer.reset);
-            idleTimer.clear();
-        };
+            return () => {
+                window.removeEventListener("click", idleTimer.reset);
+                window.removeEventListener("touchmove", idleTimer.reset);
+                window.removeEventListener("keydown", idleTimer.reset);
+                window.removeEventListener("mousemove", idleTimer.reset);
+                idleTimer.clear();
+            };
+        }
     }, [timeout]);
 
     return <IdleDetectorContext.Provider value={{state, timeout}}>{children}</IdleDetectorContext.Provider>;


### PR DESCRIPTION
Previously updated idle onTick logic #18 have flaw because onTick function have to wait for last onTick function to finish even the idle state have changed.

Now the onTick task can be cancelled when idle state changed
- onTick function will be called immediately after idle state changed
- onTick function will never be called when it is on `idle` state 